### PR TITLE
Allow parameters with spaces to be passed to the main class

### DIFF
--- a/src/main/templates/launch.mustache
+++ b/src/main/templates/launch.mustache
@@ -137,4 +137,4 @@ exec "$JAVACMD" \
      -cp "{{{EXTRA_CLASSPATH}}}${PROG_HOME}/lib/*${CLASSPATH_SUFFIX}" \
      -Dprog.home="${PROG_HOME}" \
      -Dprog.version="${PROG_VERSION}" \
-     {{{MAIN_CLASS}}} $@
+     {{{MAIN_CLASS}}} "$@"


### PR DESCRIPTION
I am currently calling the generated script like this:
script --option "foo bar"
WIthout the quotes around $@ it will end up being 3 parameters once it reaches the main class (--option, foo, bar).
