### PR TITLE
Added ability to include arbitary dependencies

### DIFF
--- a/src/main/scala/xerial/sbt/Pack.scala
+++ b/src/main/scala/xerial/sbt/Pack.scala
@@ -73,7 +73,7 @@ object Pack extends sbt.Plugin {
     packUpdateReports <<= (thisProjectRef, buildStructure, packExclude) flatMap getFromSelectedProjects(update.task),
     packPreserveOriginalJarName := false,
     packGenerateWindowsBatFile := true,
-    mappings := Seq.empty,
+    (mappings in pack) := Seq.empty,
     pack := {
       val dependentJars = collection.immutable.SortedMap.empty[ModuleEntry, File] ++ (
         for {
@@ -119,7 +119,7 @@ object Pack extends sbt.Plugin {
       }
 
       // Copy explicitly added dependencies
-      val mapped: Seq[(File, String)] = (mappings in(Compile, pack)).value
+      val mapped: Seq[(File, String)] = (mappings in pack).value
       out.log.info("explicit dependencies:")
       for ((file, path) <- mapped) {
         out.log.info(file.getPath)


### PR DESCRIPTION
I have some arbitrary files that I want to be included in my pack at a location of my choice...this lets me do that (by making use of the pre-existing mappings key)
