### PR TITLE
Replace deprecated Mac OS specific property

### DIFF
--- a/src/main/templates/launch.mustache
+++ b/src/main/templates/launch.mustache
@@ -58,7 +58,7 @@ case "`uname`" in
            if [ -z "$JAVA_HOME" ] ; then
              JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
            fi
-           JVM_OPT="$JVM_OPT -Xdock:name=${PROG_NAME} -Xdock:icon=$PROG_HOME/{{{MAC_ICON_FILE}}} -Dcom.apple.macos.useScreenMenuBar=true"
+           JVM_OPT="$JVM_OPT -Xdock:name=${PROG_NAME} -Xdock:icon=$PROG_HOME/{{{MAC_ICON_FILE}}} -Dapple.laf.useScreenMenuBar=true"
            JAVACMD="`which java`"
            ;;
 esac


### PR DESCRIPTION
When executing the launch script under Mac OS X 10.9 there is a
deprecation warning:

```
com.apple.macos.useScreenMenuBar has been deprecated. Please switch to
apple.laf.useScreenMenuBar
```

The change reflects the current Apple Java developer guide [here](https://developer.apple.com/library/mac/documentation/java/Reference/Java_PropertiesRef/Articles/JavaSystemProperties.html).
