### PR TITLE
Properly sort version strings

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -104,7 +104,8 @@ object PackBuild extends Build {
         Seq(
           "org.fusesource.scalate" % "scalate-core_2.10" % "1.6.1",
           "org.kamranzafar" % "jtar" % "2.2",
-          "org.slf4j" % "slf4j-nop" % "1.7.5"
+          "org.slf4j" % "slf4j-nop" % "1.7.5",
+          "org.specs2" %% "specs2" % "2.4.1" % "test"
         )
       )
   )

--- a/src/main/scala/xerial/sbt/Pack.scala
+++ b/src/main/scala/xerial/sbt/Pack.scala
@@ -29,7 +29,7 @@ object Pack extends sbt.Plugin {
 
   private case class ModuleEntry(org: String,
                                  name: String,
-                                 revision: String,
+                                 revision: VersionString,
                                  classifier: Option[String],
                                  originalFileName: String,
                                  projectRef: ProjectRef) {
@@ -44,7 +44,8 @@ object Pack extends sbt.Plugin {
     def noVersionJarName = "%s.%s%s.jar".format(org, name, classifierSuffix)
   }
 
-  private implicit def moduleEntryOrdering = Ordering.by[ModuleEntry, (String, String, String, Option[String])](m => (m.org, m.name, m.revision, m.classifier))
+  private implicit def versionStringOrdering = DefaultVersionStringOrdering
+  private implicit def moduleEntryOrdering = Ordering.by[ModuleEntry, (String, String, VersionString, Option[String])](m => (m.org, m.name, m.revision, m.classifier))
 
   val runtimeFilter = ScopeFilter(inAnyProject, inConfigurations(Runtime))
 
@@ -126,7 +127,7 @@ object Pack extends sbt.Plugin {
           (artifact, file) <- m.artifacts if DependencyFilter.allPass(c.configuration, m.module, artifact)}
         yield {
           val mid = m.module
-          val me = ModuleEntry(mid.organization, mid.name, mid.revision, artifact.classifier, file.getName, projectRef)
+          val me = ModuleEntry(mid.organization, mid.name, VersionString(mid.revision), artifact.classifier, file.getName, projectRef)
           me -> file
         }).filter(tuple => tuple._1.classifier == None)
 
@@ -159,7 +160,7 @@ object Pack extends sbt.Plugin {
               sys.error(s"Version conflict on ${key}: [${old._1.projectRef.project}] using $oldVersion V.S. [${jar._1.projectRef.project}] using $newVersion")
 
             out.log.warn(s"Version conflict on ${key}: [${old._1.projectRef.project}] using $oldVersion V.S. [${jar._1.projectRef.project}] using $newVersion")
-            val latest = if (oldVersion > newVersion) old else jar
+            val latest = if (versionStringOrdering.compare(oldVersion, newVersion) > 0) old else jar
             out.log.warn(s"\tUsing the latest version ${latest._1.fullJarName}")
             result += (key -> latest)
           }

--- a/src/main/scala/xerial/sbt/VersionString.scala
+++ b/src/main/scala/xerial/sbt/VersionString.scala
@@ -1,0 +1,65 @@
+//--------------------------------------
+//
+// VersionString.scala
+// Since: 2014/11/10 9:15 AM
+//
+//--------------------------------------
+
+package xerial.sbt
+
+/**
+ * Class to represent version strings
+ * @author Christian Hoffmeister
+ */
+case class VersionString(numbers: List[Int], suffix: Option[String]) {
+  def major = numbers.head
+  def minor = numbers.drop(1).headOption
+  def patch = numbers.drop(2).headOption
+
+  override def toString = (numbers, suffix) match {
+    case (n, Some(s)) if n.length > 0 => "%s-%s".format(n.mkString("."), s)
+    case (n, None) if n.length > 0 => n.mkString(".")
+    case (n, Some(s)) if n.length == 0 => s
+    case _ => ""
+  }
+}
+
+object VersionString {
+  def apply(version: String): VersionString = {
+    try {
+      val numbers = version.split("\\-", 2).head.split("\\.", -1).map(_.toInt).toList
+      val suffix = version.split("\\-", 2).tail.headOption
+      VersionString(numbers, suffix)
+    } catch {
+      case _: Exception => VersionString(Nil, Some(version))
+    }
+  }
+}
+
+object DefaultVersionStringOrdering extends Ordering[VersionString] {
+  override def compare(a: VersionString, b: VersionString): Int = {
+    def compareNumberSequence(ns1: Seq[Int], ns2: Seq[Int]): Int = (ns1, ns2) match {
+      case (Nil, Nil) => 0
+      case (n1 :: tail1, Nil) => +1
+      case (Nil, n2 :: tail2) => -1
+      case (n1 :: tail1, n2 :: tail2) =>
+        if (n1 < n2) -1
+        else if (n1 > n2) +1
+        else compareNumberSequence(tail1, tail2)
+    }
+
+    compareNumberSequence(a.numbers, b.numbers) match {
+      case res if res != 0 => res
+      case 0 =>
+        (a.suffix, b.suffix) match {
+          case (None, None) => 0
+          case (Some(s1), None) => -1
+          case (None, Some(s2)) => +1
+          case (Some(s1), Some(s2)) =>
+            if (s1 < s2) -1
+            else if (s1 > s2) +1
+            else 0
+        }
+    }
+  }
+}

--- a/src/test/scala/xerial/sbt/VersionStringSpec.scala
+++ b/src/test/scala/xerial/sbt/VersionStringSpec.scala
@@ -1,0 +1,47 @@
+package xerial.sbt
+
+import org.specs2.mutable.Specification
+
+class VersionStringSpec extends Specification {
+  implicit val versionStringOrdering = DefaultVersionStringOrdering
+
+  "VersionString" should {
+    "accept any string" in {
+      VersionString("1.0")
+      VersionString("1.0-alpha")
+      VersionString("1")
+      VersionString("-alpha")
+      VersionString("1231892")
+      VersionString("asd;.a2,.-")
+
+      ok
+    }
+
+    "properly deconstruct arbitrary string" in {
+      VersionString("1") === VersionString(1 :: Nil, None)
+      VersionString("1.2") === VersionString(1 :: 2 :: Nil, None)
+      VersionString("1.2.3") === VersionString(1 :: 2 :: 3 :: Nil, None)
+      VersionString("1.2.3.4") === VersionString(1 :: 2 :: 3 :: 4 :: Nil, None)
+      VersionString("1.2.3.4-alpha") === VersionString(1 :: 2 :: 3 :: 4 :: Nil, Some("alpha"))
+      VersionString("1.2.3.4-alpha-beta") === VersionString(1 :: 2 :: 3 :: 4 :: Nil, Some("alpha-beta"))
+      VersionString("foo") === VersionString(Nil, Some("foo"))
+      VersionString("foo.bar") === VersionString(Nil, Some("foo.bar"))
+      VersionString("foo.bar-alpha") === VersionString(Nil, Some("foo.bar-alpha"))
+    }
+
+    "properly sort" in {
+      VersionString("1") must be_<(VersionString("1.2.3.4"))
+      VersionString("2") must be_>(VersionString("1.2.3.4"))
+      VersionString("1.2.2") must be_<(VersionString("1.2.3.4"))
+      VersionString("1.2.4") must be_>(VersionString("1.2.3.4"))
+      VersionString("1.2.3.4.5") must be_>(VersionString("1.2.3.4"))
+
+      VersionString("2.9.2") must be_<(VersionString("2.10.4"))
+
+      VersionString("1.2") must be_>(VersionString("1.2-alpha"))
+      VersionString("1.2-beta") must be_>(VersionString("1.2-alpha"))
+
+      VersionString("apple") must be_<(VersionString("pie"))
+    }
+  }
+}


### PR DESCRIPTION
The default ordering DefaultVerstionStringOrdering can order version
strings according to http://semver.org. For all incompatible version
strings the fallback is default string comparison.
