### PR TITLE
Improve duplicate JAR resolving

### DIFF
--- a/src/main/scala/xerial/sbt/Pack.scala
+++ b/src/main/scala/xerial/sbt/Pack.scala
@@ -159,10 +159,8 @@ object Pack extends sbt.Plugin {
                 latest
               case "exit" =>
                 sys.error(s"Version conflict on $key (found ${revisions.mkString(", ")})")
-                ???
               case x =>
                 sys.error("Unknown duplicate JAR strategy '%s'".format(x))
-                ???
             }
         }
         .toMap


### PR DESCRIPTION
Just a minor code style tweak that makes the resolving IMHO more obvious und more functional.

In addition, now on conflicts there is printed a single warning (per `noVersionJarName`) like

```
[warn] Version conflict on com.mycompany. Using 1.2.3 (found 1.0, 1.2.3-alpha, 1.2.3)
```

instead of multiple warnings for each found conflicting version.
