### PR TITLE
Better handling of sub-projects in packAutoSettings

### DIFF
--- a/src/sbt-test/sbt-pack/duplicate-jars/project/Build.scala
+++ b/src/sbt-test/sbt-pack/duplicate-jars/project/Build.scala
@@ -5,19 +5,16 @@ import xerial.sbt.Pack._
 
 object Build extends sbt.Build {
 
-  val commonSettings = Defaults.defaultSettings ++
-    // Add pack settings to common, so that packMain is available in subprojects' scope
-    packAutoSettings ++
-    Seq(
-      scalaVersion := "2.10.3",
-      version := "0.1",
-      crossPaths := false
+  val commonSettings = Defaults.defaultSettings ++ Seq(
+    scalaVersion := "2.10.3",
+    version := "0.1",
+    crossPaths := false
   )
 
   lazy val root = Project(
     id = "duplicate-jars",
     base = file("."),
-    settings = commonSettings ++
+    settings = commonSettings ++ packAutoSettings ++
       Seq(
         // custom settings here
       )

--- a/src/sbt-test/sbt-pack/multi-module/project/Build.scala
+++ b/src/sbt-test/sbt-pack/multi-module/project/Build.scala
@@ -5,10 +5,7 @@ import xerial.sbt.Pack._
 
 object Build extends sbt.Build {
 
-  val commonSettings = Defaults.defaultSettings ++
-    // Add pack settings to common, so that packMain is available in subprojects' scope
-    packAutoSettings ++
-    Seq(
+  val commonSettings = Defaults.defaultSettings ++ Seq(
      scalaVersion := "2.10.3",
      version := "0.1",
      crossPaths := false
@@ -17,7 +14,7 @@ object Build extends sbt.Build {
   lazy val root = Project(
     id = "multi-module",
     base = file("."),
-    settings = commonSettings ++
+    settings = commonSettings ++ packAutoSettings ++
       Seq(
         // custom settings here
       )


### PR DESCRIPTION
This should fix https://github.com/xerial/sbt-pack/issues/47 and https://github.com/xerial/sbt-pack/issues/55.

This slightly changes my implementation of the way main classes are discovered, handling smoothly sub-projects: this allows one not to add `packAutoSettings` in all the sub-projects, as was required before (which led to https://github.com/xerial/sbt-pack/issues/47 and https://github.com/xerial/sbt-pack/issues/55). The tests were changed accordingly, and illustrate that.

Tell me if you have any remark/question.