### PR TITLE
proper handling of modules with multiple artifacts

### DIFF
--- a/src/main/scala/xerial/sbt/Pack.scala
+++ b/src/main/scala/xerial/sbt/Pack.scala
@@ -298,7 +298,7 @@ object Pack extends sbt.Plugin with PackArchive {
 
   lazy val packAutoSettings = packSettings :+ (
     packMain := packMainDiscovered.value
-    )
+  )
 
 
   private def getFromAllProjects[T](targetTask: TaskKey[T])(currentProject: ProjectRef, structure: BuildStructure): Task[Seq[(T, ProjectRef)]] =


### PR DESCRIPTION
I'm using SBT pack and was running into a classnotfound exception.
We have a company ivy repository.
I'm trying to use the jackson dependency from this repo, which is no issue for sbt.

After investigation it became clear that sbt-pack only included one of the 3 artifact jars that make up jackson 2.2.2.
Please review this pull request as it seems to resolve this issue for me.