### PR TITLE
new setting, packExcludeJars, to filter jars by name patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ object Build extends sbt.Build {
         //   "no-version" (organization name).(project name).jar
         //   "original"  (Preserve original jar file names)
         packJarNameConvention := "default",
+        // [Optional] Patterns of jar file names to exclude in pack
+        packExcludeJars := Seq("scala-.*\\.jar"),
         // [Optional] List full class paths in the launch scripts (default is false) (since 0.5.1)
         packExpandedClasspath := false,
         // [Optional] Resource directory mapping to be copied within target/pack. Default is Map("{projectRoot}/src/pack" -> "") 

--- a/src/main/scala/xerial/sbt/Pack.scala
+++ b/src/main/scala/xerial/sbt/Pack.scala
@@ -52,6 +52,7 @@ object Pack extends sbt.Plugin with PackArchive {
   val packMain = TaskKey[Map[String, String]]("prog_name -> main class table")
   val packMainDiscovered = TaskKey[Map[String, String]]("discovered prog_name -> main class table")
   val packExclude = SettingKey[Seq[String]]("pack-exclude", "specify projects to exclude when packaging")
+  val packExcludeJars = SettingKey[Seq[String]]("pack-exclude-jars", "specify jar file name patterns to exclude when packaging")
   val packExcludeArtifactTypes = settingKey[Seq[String]]("specify artifact types (e.g. javadoc) to exclude when packaging")
   val packAllClasspaths = TaskKey[Seq[(Classpath, ProjectRef)]]("pack-all-classpaths")
   val packLibJars = TaskKey[Seq[(File, ProjectRef)]]("pack-lib-jars")
@@ -98,6 +99,7 @@ object Pack extends sbt.Plugin with PackArchive {
         allDiscoveredMainClasses.flatMap(_._1.map(mainClass => hyphenize(mainClass.split('.').last) -> mainClass).toMap).toMap
     },
     packExclude := Seq.empty,
+    packExcludeJars := Seq.empty,
     packExcludeArtifactTypes := Seq("source", "javadoc", "test"),
     packMacIconFile := "icon-mac.png",
     packResourceDir := Map(baseDirectory.value / "src/pack" -> ""),
@@ -129,7 +131,7 @@ object Pack extends sbt.Plugin with PackArchive {
           (r: sbt.UpdateReport, projectRef) <- packUpdateReports.value
           c <- r.configurations if c.configuration == "runtime"
           m <- c.modules
-          (artifact, file) <- m.artifacts if !packExcludeArtifactTypes.value.contains(artifact.`type`)
+          (artifact, file) <- m.artifacts if !packExcludeArtifactTypes.value.contains(artifact.`type`) && !packExcludeJars.value.exists(file.name.matches)
         } yield {
           val mid = m.module
           val me = ModuleEntry(mid.organization, mid.name, VersionString(mid.revision), artifact.name, artifact.classifier, file.getName, projectRef)


### PR DESCRIPTION
Added a new setting, packExcludeJars, to filter packed jars based on file name regular expression patterns.

Signed-off-by: Nicolas Rouquette <nicolas.f.rouquette@jpl.nasa.gov>