### PR TITLE
Always quoting java path in launch-bat

### DIFF
--- a/src/main/templates/launch-bat.mustache
+++ b/src/main/templates/launch-bat.mustache
@@ -35,7 +35,7 @@ if "%OS%"=="Windows_NT" @setlocal
 if not "%JAVA_HOME%" == "" goto OkJHome
 
 for /f %%j in ("java.exe") do (
-  set JAVA_EXE=%%~$PATH:j
+  set JAVA_EXE="%%~$PATH:j"
   goto init
 )
 


### PR DESCRIPTION
This PR makes the generated bat launchers work when `JAVA_HOME` is not set and the path of `java.exe` contains spaces.

I'm no bat script expert by the way. Quoting like is the way it should be done, right? It makes things work for me.