### PR TITLE
Make packExcludeJars test more precise

### DIFF
--- a/src/sbt-test/sbt-pack/exclude-jars/build.sbt
+++ b/src/sbt-test/sbt-pack/exclude-jars/build.sbt
@@ -1,10 +1,9 @@
 packAutoSettings
-scalaVersion := "2.10.5"
+scalaVersion := "2.10.4"
 crossPaths := false
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.4.0" % "provided",
-  "com.typesafe.play" %% "play-json" % "2.3.9"
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
 )
 
 packExcludeJars := Seq("scala-library.*\\.jar", "scala-reflect.*\\.jar")


### PR DESCRIPTION
The issue #77 was not related to `spark-core` or `play-json`, neither to the difference between `scalaVersion` and `scala-reflect`'s version, nor to the transitive dependency.