### PR TITLE
#89: Implemented packArchivePosixMask mechanism

### DIFF
--- a/src/main/scala/xerial/sbt/PackArchive.scala
+++ b/src/main/scala/xerial/sbt/PackArchive.scala
@@ -75,8 +75,7 @@ trait PackArchive {
     else
       None
 
-  val posixMaskFromBinPath: File => Option[Int] = {
-    val distDir: File = Pack.pack.value
+  def posixMaskFromBinPath(distDir: File): File => Option[Int] = {
     val binDir = distDir / "bin"
     posixMaskFromPath(binDir) _
   }
@@ -105,7 +104,8 @@ trait PackArchive {
     packArchiveTbzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.bz2"),
     packArchiveTxzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.xz"),
     packArchiveZipArtifact := Artifact(packArchivePrefix.value, "arch", "zip"),
-    packArchivePosixMask := posixMaskFromBinPath,
+    packArchivePosixMask := posixMaskFromBinPath(Pack.packTargetDir.value / Pack.packDir.value),
+
     packArchiveTgz := createArchive("tar.gz",
       (fos) => createTarArchiveOutputStream(new GzipCompressorOutputStream(fos)),
       createTarEntry).value,


### PR DESCRIPTION
Hi,

I managed to implement a possible solution at https://github.com/xerial/sbt-pack/issues/89.

The following setting implements the desired behaviour
```scala
packArchivePosixMask := posixMaskFromFilesystem
```
The following setting implements the default behaviour
```scala
packArchivePosixMask := posixMaskFromBinPath(Pack.packTargetDir.value / Pack.packDir.value)
```
The following setting prevents masks from being set in the archive
```scala
packArchivePosixMask := posixMaskNone
```
It should be ready for you to review, adjust and integrate

Cheers
Nico