### PR TITLE
Switch from slf4j-nop to slf4j-simple

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -106,7 +106,7 @@ object PackBuild extends Build {
           "org.fusesource.scalate" % "scalate-core_2.10" % "1.6.1",
           "org.apache.commons" % "commons-compress" % "1.9",
           "org.tukaani" % "xz" % "1.5",
-          "org.slf4j" % "slf4j-nop" % "1.7.5",
+          "org.slf4j" % "slf4j-simple" % "1.7.5",
           "org.specs2" %% "specs2" % "2.4.1" % "test"
         )
       )


### PR DESCRIPTION
This is to avoid conflicts with other plugins which also
depend on slf4j-simple.

Fixes #93