### PR TITLE
Add separate setting for root directory name within archive

### DIFF
--- a/src/main/scala/xerial/sbt/PackArchive.scala
+++ b/src/main/scala/xerial/sbt/PackArchive.scala
@@ -14,6 +14,7 @@ import org.apache.commons.compress.utils.IOUtils
 trait PackArchive {
   val packArchivePrefix = SettingKey[String]("prefix of (prefix)-(version).(format) archive file name")
   val packArchiveName = SettingKey[String]("archive file name. Default is (project-name)-(version)")
+  val packArchiveStem = SettingKey[String]("directory name within the archive. Default is (archive-name)")
   val packArchiveExcludes = SettingKey[Seq[String]]("List of excluding files from the archive")
   val packArchiveTgzArtifact = SettingKey[Artifact]("tar.gz archive artifact")
   val packArchiveTbzArtifact = SettingKey[Artifact]("tar.bz2 archive artifact")
@@ -33,8 +34,8 @@ trait PackArchive {
     val targetDir: File = Pack.packTargetDir.value
     val distDir: File = Pack.pack.value // run pack command here
     val binDir = distDir / "bin"
-    val archiveStem = s"${packArchiveName.value}"
-    val archiveName = s"${archiveStem}.${archiveSuffix}"
+    val archiveStem = s"${packArchiveStem.value}"
+    val archiveName = s"${packArchiveName.value}.${archiveSuffix}"
     out.log.info("Generating " + rpath(baseDirectory.value, targetDir / archiveName))
     val aos = createOutputStream(new BufferedOutputStream(new FileOutputStream(targetDir / archiveName)))
     val excludeFiles = packArchiveExcludes.value.toSet
@@ -80,6 +81,7 @@ trait PackArchive {
   lazy val packArchiveSettings = Seq[Def.Setting[_]](
     packArchivePrefix := name.value,
     packArchiveName := s"${packArchivePrefix.value}-${version.value}",
+    packArchiveStem := s"${packArchiveName.value}",
     packArchiveExcludes := Seq.empty,
     packArchiveTgzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.gz"),
     packArchiveTbzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.bz2"),


### PR DESCRIPTION
I recently ran into the same problem as #99 so I made a very simple change to split off the setting used for the name of the directory inside the archive into its own setting.

It retains the existing behaviour by default. To specify no root directory, use `packArchiveStem := "."`.

Let me know if you need anything else!