### PR TITLE
Make launcher work on mingw

### DIFF
--- a/src/main/templates/launch.mustache
+++ b/src/main/templates/launch.mustache
@@ -120,9 +120,9 @@ fi
 # For Migwn, ensure paths are in UNIX format before anything is touched
 if $mingw ; then
   [ -n "$PROG_HOME" ] &&
-    PROG_HOME="`(cd "$PROG_HOME"; pwd)`"
+    PROG_HOME="`(cd "$PROG_HOME"; pwd -W | sed 's|/|\\\\|g')`"
   [ -n "$JAVA_HOME" ] &&
-    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd -W | sed 's|/|\\\\|g')`"
   CLASSPATH_SUFFIX=";"
   PSEP=";"
 fi
@@ -131,7 +131,7 @@ fi
 PROG_NAME={{{PROG_NAME}}}
 PROG_VERSION={{{PROG_VERSION}}}
 
-eval exec "$JAVACMD" \
+eval exec "\"$JAVACMD\"" \
      {{{JVM_OPTS}}} \
      ${JAVA_OPTS} \
      {{^EXPANDED_CLASSPATH}}


### PR DESCRIPTION
 * When runnig from mingw we convert all paths to windows paths. All
   paths to java need to be windows paths (like in the cygwin case).
   We can not rely on the mingw posix path conversion because it is
   set out of play because of a lot of quotes etc.
 * The luncer did not handle spaces in the path to the java
   executable but that is now also fixed
 * fix #87