### PR TITLE
Update Readme file's Docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ COPY target/pack /srv/myapp
 USER nobody
 WORKDIR /srv/myapp
 
-ENTRYPOINT ["./bin/myapp"]
+ENTRYPOINT ["sh", "./bin/myapp"]
 ```
 
 Then you can build a docker image of your project:
@@ -218,7 +218,7 @@ $ docker build -t your_org/myapp:latest .
 
 
 # Run your application with Docker
-$ docker run -it -rm your_org/myapp:latest (command line arg...)
+$ docker run -it --rm your_org/myapp:latest (command line arg...)
 ```
 
 	


### PR DESCRIPTION
Fixed minor typos in the Docker section (Related to #115)
- ENTRYPOINT switched to a shell-oriented value (which BTW is not the favored way) so it works with images protecting access to their shell commands
- the -rm switch has been replaced to --rm, which fixes a bad option error when starting the Docker image. That is if the intention was to make and example where the container is dropped once exited