### PR TITLE
change the behavior of getting git revision

### DIFF
--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -273,14 +273,10 @@ object PackPlugin extends AutoPlugin with PackArchive {
       val macIconFile = packMacIconFile.value
 
       // Check the current Git revision
-      val gitRevision: String = Try {
-        // if((base / ".git").exists()) {
-          out.log.info(logPrefix + "Checking the git revision of the current project")
-          sys.process.Process("git rev-parse HEAD").!!
-        // }
-        // else {
-          // "unknown"
-        // }
+      val gitRevision = Try {
+        out.log.info(logPrefix + "Checking the git revision of the current project")
+        val s = sys.process.Process("git rev-parse HEAD") lineStream_! sys.process.ProcessLogger(_ => {}, _ => {})
+        s.head
       }.getOrElse("unknown").trim
 
       val pathSeparator = "${PSEP}"

--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -274,13 +274,13 @@ object PackPlugin extends AutoPlugin with PackArchive {
 
       // Check the current Git revision
       val gitRevision: String = Try {
-        if((base / ".git").exists()) {
+        // if((base / ".git").exists()) {
           out.log.info(logPrefix + "Checking the git revision of the current project")
           sys.process.Process("git rev-parse HEAD").!!
-        }
-        else {
-          "unknown"
-        }
+        // }
+        // else {
+          // "unknown"
+        // }
       }.getOrElse("unknown").trim
 
       val pathSeparator = "${PSEP}"


### PR DESCRIPTION
In my case, our codes are in one git repo, but be seperated to diffrent dir by module or function.
All these modules are the same git version,  the git command "git rev-parse HEAD" does not need to be executed in the directory where exactly has the .git dir.