### PR TITLE
Feature/gitrevision

### DIFF
--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -273,14 +273,10 @@ object PackPlugin extends AutoPlugin with PackArchive {
       val macIconFile = packMacIconFile.value
 
       // Check the current Git revision
-      val gitRevision: String = Try {
-        // if((base / ".git").exists()) {
-          out.log.info(logPrefix + "Checking the git revision of the current project")
-          sys.process.Process("git rev-parse HEAD").!!
-        // }
-        // else {
-          // "unknown"
-        // }
+      val gitRevision = Try {
+        out.log.info(logPrefix + "Checking the git revision of the current project")
+        val s = sys.process.Process("git rev-parse HEAD") lineStream_! sys.process.ProcessLogger(_ => {}, _ => {})
+        s.head
       }.getOrElse("unknown").trim
 
       val pathSeparator = "${PSEP}"

--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -274,13 +274,13 @@ object PackPlugin extends AutoPlugin with PackArchive {
 
       // Check the current Git revision
       val gitRevision: String = Try {
-        if((base / ".git").exists()) {
+        // if((base / ".git").exists()) {
           out.log.info(logPrefix + "Checking the git revision of the current project")
           sys.process.Process("git rev-parse HEAD").!!
-        }
-        else {
-          "unknown"
-        }
+        // }
+        // else {
+          // "unknown"
+        // }
       }.getOrElse("unknown").trim
 
       val pathSeparator = "${PSEP}"


### PR DESCRIPTION
Optimization the behavior of getting git revision, when use `sbt pack` in a dir not exactly has the `.git` dir(e.g. a git repo's subdir), the `VERSION` file does not get the git revision.

In my case, our codes are in one git repo, but be seperated to diffrent subdir according to module or function. All these modules are the same git version, the git command "git rev-parse HEAD" does not need to be executed in the directory where exactly has the .git dir. 

This change would not harm the final result the `sbt pack` do.

Maybe someone have the same situation?