### PR TITLE
gz or zip file may rename to jar in copy project dependencies

### DIFF
--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -154,7 +154,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
           c                <- update.value.filter(df).configurations
           m                <- c.modules if !m.evicted
           (artifact, file) <- m.artifacts
-          if !packExcludeArtifactTypes.value.contains(artifact.`type`) && !isExcludeJar(file.name)
+          if !packExcludeArtifactTypes.value.contains(artifact.`type`) && !isExcludeJar(file.name) && file.getName.endsWith(".jar")
         } yield {
           val mid = m.module
           ModuleEntry(mid.organization, mid.name, VersionString(mid.revision), artifact.name, artifact.classifier, file)


### PR DESCRIPTION
When repository url is "https://repo1.maven.org/maven2/" and get jar "log4j-1.2.17" or "log4j1.2.16", use command 'sbt pack' will rename log4j-1.2.17.tar.gz to log4j-1.2.17.jar.

 In sbt-pack copy project dependencies code variable distinctDpJars include three file ("log4j-1.2.17.jar", "log4j-1.2.17.tar.gz", "log4j-1.2.17.zip"),and function "resolveJarName(m, jarNameConvention)" cause jar file be renamed in fact.