### PR TITLE
write the list of copied jars into a file when packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ packJarNameConvention := "default",
 // [Optional] Patterns of jar file names to exclude in pack
 packExcludeJars := Seq("scala-.*\\.jar")
 
+// [Optional] Generate a text file containing the list of copied jars.
+packJarListFile := Some("lib/jars.mf")
+
 // [Optional] List full class paths in the launch scripts (default is false) (since 0.5.1)
 packExpandedClasspath := false
 // [Optional] Resource directory mapping to be copied within target/pack. Default is Map("{projectRoot}/src/pack" -> "") 


### PR DESCRIPTION
I would like to know what are the list of jars copied, so that I can do some post-processing after packing and also during runtime.

This patch collects the list of destination paths that were copied to, then write it out into `lib/jars.mf` after making each path relative to `distDir`.
