### PR TITLE
Ability to pack test scoped jars #110

### DIFF
--- a/src/main/scala/xerial/sbt/pack/PackArchive.scala
+++ b/src/main/scala/xerial/sbt/pack/PackArchive.scala
@@ -112,25 +112,17 @@ trait PackArchive {
     Def.derive(packArchive    := Seq(packArchiveTgz.value, packArchiveZip.value))
   )
 
-  def publishPackArchiveTgz: SettingsDefinition = Seq(
-    artifacts += packArchiveTgzArtifact.value,
-    packagedArtifacts += packArchiveTgzArtifact.value -> packArchiveTgz.value
-  )
+  def publishPackArchiveTgz: SettingsDefinition =
+    addArtifact(Def.setting(packArchiveTgzArtifact.value), Runtime / packArchiveTgz)
 
-  def publishPackArchiveTbz: SettingsDefinition = Seq(
-    artifacts += packArchiveTbzArtifact.value,
-    packagedArtifacts += packArchiveTbzArtifact.value -> packArchiveTbz.value
-  )
+  def publishPackArchiveTbz: SettingsDefinition =
+    addArtifact(Def.setting(packArchiveTbzArtifact.value), Runtime / packArchiveTbz)
 
-  def publishPackArchiveTxz: SettingsDefinition = Seq(
-    artifacts += packArchiveTxzArtifact.value,
-    packagedArtifacts += packArchiveTxzArtifact.value -> packArchiveTxz.value
-  )
+  def publishPackArchiveTxz: SettingsDefinition =
+    addArtifact(Def.setting(packArchiveTxzArtifact.value), Runtime / packArchiveTxz)
 
-  def publishPackArchiveZip: SettingsDefinition = Seq(
-    artifacts += packArchiveZipArtifact.value,
-    packagedArtifacts += packArchiveZipArtifact.value -> packArchiveZip.value
-  )
+  def publishPackArchiveZip: SettingsDefinition =
+    addArtifact(Def.setting(packArchiveZipArtifact.value), Runtime / packArchiveZip)
 
   def publishPackArchives: SettingsDefinition =
     publishPackArchiveTgz ++ publishPackArchiveZip

--- a/src/main/scala/xerial/sbt/pack/PackArchive.scala
+++ b/src/main/scala/xerial/sbt/pack/PackArchive.scala
@@ -87,23 +87,29 @@ trait PackArchive {
     packArchiveTbzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.bz2"),
     packArchiveTxzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.xz"),
     packArchiveZipArtifact := Artifact(packArchivePrefix.value, "arch", "zip"),
-    packArchiveTgz := createArchive(
-      "tar.gz",
-      (fos) => createTarArchiveOutputStream(new GzipCompressorOutputStream(fos)),
-      createTarEntry
-    ).value,
-    packArchiveTbz := createArchive(
-      "tar.bz2",
-      (fos) => createTarArchiveOutputStream(new BZip2CompressorOutputStream(fos)),
-      createTarEntry
-    ).value,
-    packArchiveTxz := createArchive(
-      "tar.xz",
-      (fos) => createTarArchiveOutputStream(new XZCompressorOutputStream(fos)),
-      createTarEntry
-    ).value,
-    packArchiveZip := createArchive("zip", new ZipArchiveOutputStream(_), createZipEntry).value,
-    packArchive    := Seq(packArchiveTgz.value, packArchiveZip.value)
+    Def.derive(
+      packArchiveTgz := createArchive(
+        "tar.gz",
+        (fos) => createTarArchiveOutputStream(new GzipCompressorOutputStream(fos)),
+        createTarEntry
+      ).value
+    ),
+    Def.derive(
+      packArchiveTbz := createArchive(
+        "tar.bz2",
+        (fos) => createTarArchiveOutputStream(new BZip2CompressorOutputStream(fos)),
+        createTarEntry
+      ).value
+    ),
+    Def.derive(
+      packArchiveTxz := createArchive(
+        "tar.xz",
+        (fos) => createTarArchiveOutputStream(new XZCompressorOutputStream(fos)),
+        createTarEntry
+      ).value
+    ),
+    Def.derive(packArchiveZip := createArchive("zip", new ZipArchiveOutputStream(_), createZipEntry).value),
+    Def.derive(packArchive    := Seq(packArchiveTgz.value, packArchiveZip.value))
   )
 
   def publishPackArchiveTgz: SettingsDefinition = Seq(

--- a/src/sbt-test/sbt-pack/archive-modules/test
+++ b/src/sbt-test/sbt-pack/archive-modules/test
@@ -1,5 +1,6 @@
 > 'set version := "0.1"'
 > packArchive
+> packagedArtifacts
 $ exists target/archive-modules-0.1.tar.gz
 $ exists target/archive-modules-0.1.zip
 $ exists target/pack/bin/module1


### PR DESCRIPTION
Using Def.derive allows to propagate Compile/Test configurations.

Therefore `Compile / pack` packs without the tests and `Test / pack` packs with the tests.