### PR TITLE
Fix duplicate 'FROM' in Dockerfile example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ packMain := Map("myapp"->"org.yourdomain.MyApp")
 **Dockerfile**
 ```
 # Using JDK17 from Amazon Corretto
-FROM FROM amazoncorretto:17
+FROM amazoncorretto:17
 
 COPY target/pack /srv/myapp
 


### PR DESCRIPTION
The example Dockerfile in the README.md had a typo with a repeated 'FROM' keyword. This commit removes the duplicate 'FROM', ensuring the Dockerfile example is correct and can be used as-is without modifications.