### PR TITLE
Use POSIX compliant `command -v`

### DIFF
--- a/src/main/twirl/xerial/sbt/pack/launch.scala.txt
+++ b/src/main/twirl/xerial/sbt/pack/launch.scala.txt
@@ -60,16 +60,16 @@ case "`uname`" in
              JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
            fi
            JAVA_OPTS="$JAVA_OPTS -Xdock:name=\"${PROG_NAME}\" -Xdock:icon=\"$PROG_HOME/@(opts.MAC_ICON_FILE)\" -Dapple.laf.useScreenMenuBar=true"
-           JAVACMD="`which java`"
+           JAVACMD="`command -v java`"
            ;;
 esac
 
 # Resolve JAVA_HOME from javac command path
 if [ -z "$JAVA_HOME" ]; then
-  javaExecutable="`which javac`"
+  javaExecutable="`command -v javac`"
   if [ -n "$javaExecutable" -a -f "$javaExecutable" -a ! "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
     # readlink(1) is not available as standard on Solaris 10.
-    readLink=`which readlink`
+    readLink=`command -v readlink`
     if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
       javaExecutable="`readlink -f \"$javaExecutable\"`"
       javaHome="`dirname \"$javaExecutable\"`"
@@ -90,7 +90,7 @@ if [ -z "$JAVACMD" ] ; then
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   else
-    JAVACMD="`which java`"
+    JAVACMD="`command -v java`"
   fi
 fi
 


### PR DESCRIPTION
This removes the `which` package dependency, allowing Linux containers to run with this additional package. See https://github.com/xerial/sbt-pack/issues/425 where I previously discussed this.

Example:

```
[kevin@fedora ~]$ which java
~/.sdkman/candidates/java/current/bin/java
[kevin@fedora ~]$ command -v java
/home/kevin/.sdkman/candidates/java/current/bin/java

[kevin@fedora ~]$ which scalac
~/.sdkman/candidates/scala/current/bin/scalac
[kevin@fedora ~]$ command -v scalac
/home/kevin/.sdkman/candidates/scala/current/bin/scalac

[kevin@fedora ~]$ which readlink
/usr/bin/readlink
[kevin@fedora ~]$ command -v readlink
/usr/bin/readlink
[kevin@fedora ~]$ 
```

Do note that POSIX dictates hard references, no ~/ support.