### PR TITLE
Add release workflow for automated publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  publish_jvm:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10000
+      - run: git fetch --tags -f
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Setup GPG
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      - name: Build bundle
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        run: |
+          ./sbt publishSigned
+      - name: Release to Sonatype
+        env:
+          SONATYPE_USERNAME: '${{ secrets.SONATYPE_USERNAME }}'
+          SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASSWORD }}'
+        run: ./sbt sonaRelease


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow for automated release process
- Based on the release workflow from snappy-java project
- Automates publishing signed artifacts to Maven Central

## Details
This PR adds a `.github/workflows/release.yml` file that:
- Triggers on version tags (v*) or manual workflow dispatch
- Sets up Java 11 with Zulu distribution
- Configures GPG signing for artifacts
- Publishes signed artifacts to Sonatype
- Releases to Maven Central via sonatypeRelease

## Required Configuration
The following secrets need to be configured in the repository settings:
- `PGP_SECRET`: Base64 encoded GPG private key for signing artifacts
- `PGP_PASSPHRASE`: Passphrase for the GPG key
- `SONATYPE_USERNAME`: Username for Sonatype/Maven Central
- `SONATYPE_PASSWORD`: Password for Sonatype/Maven Central

## Test Plan
- [ ] Verify workflow syntax is valid
- [ ] Test with a release candidate tag after secrets are configured
- [ ] Confirm artifacts are properly signed and published

🤖 Generated with [Claude Code](https://claude.ai/code)