### PR TITLE
Upgrade CI workflows to Java 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
       - run: git fetch --tags -f
       - uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '21'
       - name: Setup GPG
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: olafurpg/setup-scala@v14
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: 'temurin'
+          java-version: '21'
       - name: scripted tests
         run: ./sbt scripted


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions workflows from Java 11 to Java 21
- Switch to Eclipse Temurin distribution for consistency
- Replace deprecated `olafurpg/setup-scala` action with `actions/setup-java`

## Motivation
The current CI configuration uses Java 11 which produces JVMCI compiler warnings during builds:
```
Thread[JVMCI CompilerThread0,9,system]: Compilation of java.util.zip.ZipEntry.getTime() failed: java.lang.AssertionError: dependencies invalid
```

This PR upgrades to Java 21 to:
- Resolve the JVMCI compiler warnings
- Use a more recent LTS version of Java
- Ensure compatibility with modern Java features

## Test plan
- [x] CI workflows updated
- [ ] Wait for CI to pass on this PR to verify Java 21 compatibility
- [ ] All existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)