### PR TITLE
Add cross-building support for sbt 2.0.0-RC2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,24 +47,24 @@ jobs:
       - name: scripted tests (sbt 1.x)
         run: ./sbt "++ 2.12 test" "++ 2.12 scripted"
 
-  # test_sbt2_plugin:
-  #   name: plugin test (sbt 2.x)
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - os: ubuntu-latest
-  #           distribution: temurin
-  #           java: 21
-  #         - os: ubuntu-latest
-  #           distribution: temurin
-  #           java: 24
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-java@v4
-  #       with:
-  #         distribution: "${{ matrix.distribution }}"
-  #         java-version: "${{ matrix.java }}"
-  #     - name: scripted tests (sbt 2.x)
-  #       run: ./sbt "++ 3 test" "++ 3 scripted"
+  test_sbt2_plugin:
+    name: plugin test (sbt 2.x)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            distribution: temurin
+            java: 21
+          - os: ubuntu-latest
+            distribution: temurin
+            java: 24
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "${{ matrix.distribution }}"
+          java-version: "${{ matrix.java }}"
+      - name: scripted tests (sbt 2.x)
+        run: ./sbt "++ 3 test" "++ 3 scripted"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ pluginCrossBuild / sbtVersion := {
     case "2.12" =>
       (pluginCrossBuild / sbtVersion).value
     case _ =>
-      "2.0.0-M4"
+      "2.0.0-RC2"
   }
 }
 

--- a/src/main/scala-3/xerial/sbt/pack/PluginCompat.scala
+++ b/src/main/scala-3/xerial/sbt/pack/PluginCompat.scala
@@ -4,6 +4,9 @@ import java.nio.file.Path as NioPath
 import sbt.*
 import sbt.internal.inc.PlainVirtualFileConverter
 import xsbti.{FileConverter, HashedVirtualFileRef, VirtualFile}
+import sjsonnew.JsonFormat
+import sbt.util.CacheImplicits.hashedVirtualFileRefIsoString
+import sbt.internal.util.codec.JsonProtocol.given
 
 // See https://www.eed3si9n.com/sbt-assembly-2.3.0
 private[pack] object PluginCompat:
@@ -11,6 +14,9 @@ private[pack] object PluginCompat:
   type Out     = VirtualFile
 
   given conv: FileConverter = PlainVirtualFileConverter.converter
+  
+  // Provide JsonFormat for FileRef (required for sbt 2.x)
+  given fileRefFormat: JsonFormat[FileRef] = summon[JsonFormat[HashedVirtualFileRef]]
 
   implicit def toFile(a: HashedVirtualFileRef): File = conv.toPath(a).toFile
   implicit def toFileRef(a: File): FileRef           = conv.toVirtualFile(a.toPath)

--- a/src/main/scala/xerial/sbt/pack/PackArchive.scala
+++ b/src/main/scala/xerial/sbt/pack/PackArchive.scala
@@ -89,31 +89,23 @@ trait PackArchive {
     packArchiveTbzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.bz2"),
     packArchiveTxzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.xz"),
     packArchiveZipArtifact := Artifact(packArchivePrefix.value, "arch", "zip"),
-    Def.derive(
-      packArchiveTgz := createArchive[TarArchiveEntry](
-        "tar.gz",
-        (fos) => createTarArchiveOutputStream(new GzipCompressorOutputStream(fos)),
-        createTarEntry
-      ).value
-    ),
-    Def.derive(
-      packArchiveTbz := createArchive[TarArchiveEntry](
-        "tar.bz2",
-        (fos) => createTarArchiveOutputStream(new BZip2CompressorOutputStream(fos)),
-        createTarEntry
-      ).value
-    ),
-    Def.derive(
-      packArchiveTxz := createArchive[TarArchiveEntry](
-        "tar.xz",
-        (fos) => createTarArchiveOutputStream(new XZCompressorOutputStream(fos)),
-        createTarEntry
-      ).value
-    ),
-    Def.derive(
-      packArchiveZip := createArchive[ZipArchiveEntry]("zip", new ZipArchiveOutputStream(_), createZipEntry).value
-    ),
-    Def.derive(packArchive := Seq(packArchiveTgz.value, packArchiveZip.value))
+    packArchiveTgz := createArchive[TarArchiveEntry](
+      "tar.gz",
+      (fos) => createTarArchiveOutputStream(new GzipCompressorOutputStream(fos)),
+      createTarEntry
+    ).value,
+    packArchiveTbz := createArchive[TarArchiveEntry](
+      "tar.bz2",
+      (fos) => createTarArchiveOutputStream(new BZip2CompressorOutputStream(fos)),
+      createTarEntry
+    ).value,
+    packArchiveTxz := createArchive[TarArchiveEntry](
+      "tar.xz",
+      (fos) => createTarArchiveOutputStream(new XZCompressorOutputStream(fos)),
+      createTarEntry
+    ).value,
+    packArchiveZip := createArchive[ZipArchiveEntry]("zip", new ZipArchiveOutputStream(_), createZipEntry).value,
+    packArchive := Seq(packArchiveTgz.value, packArchiveZip.value)
   )
 
   def publishPackArchiveTgz: SettingsDefinition =

--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -165,28 +165,25 @@ object PackPlugin extends AutoPlugin with PackArchive {
         getFromSelectedProjects(thisProjectRef.value, Runtime, unmanagedJars, state.value, packExclude.value)
       Def.task { allUnmanagedJars.value }
     }.value,
-    Def.derive(
-      packLibJars := Def.taskDyn {
-        def libJarsFromConfiguration(c: Configuration): Seq[Task[Seq[(FileRef, ProjectRef)]]] =
-          Seq(
-            getFromSelectedProjects[FileRef](
-              thisProjectRef.value,
-              c,
-              packageBin,
-              state.value,
-              packExcludeLibJars.value
-            )
-          ) ++ c.extendsConfigs.flatMap(libJarsFromConfiguration)
+    packLibJars := Def.taskDyn {
+      def libJarsFromConfiguration(c: Configuration): Seq[Task[Seq[(FileRef, ProjectRef)]]] =
+        Seq(
+          getFromSelectedProjects[FileRef](
+            thisProjectRef.value,
+            c,
+            packageBin,
+            state.value,
+            packExcludeLibJars.value
+          )
+        ) ++ c.extendsConfigs.flatMap(libJarsFromConfiguration)
 
-        val libJars = libJarsFromConfiguration(configuration.value).join
-        Def.task {
-          libJars.value.flatten.distinct
-        }
-      }.value
-    ),
+      val libJars = libJarsFromConfiguration(configuration.value).join
+      Def.task {
+        libJars.value.flatten.distinct
+      }
+    }.value,
     mappings := Seq.empty,
-    Def.derive(
-      packModuleEntries := {
+    packModuleEntries := {
         val out                          = streams.value
         val jarExcludeFilter: Seq[Regex] = packExcludeJars.value.map(_.r)
         def isExcludeJar(name: String): Boolean = {
@@ -237,12 +234,10 @@ object PackPlugin extends AutoPlugin with PackArchive {
               }
           }
         distinctDpJars.toSeq.distinct.sortBy(_.noVersionModuleName)
-      }
-    ),
+    },
     packCopyDependenciesUseSymbolicLinks := true,
     packCopyDependenciesTarget           := target.value / "lib",
-    Def.derive(
-      packCopyDependencies := {
+    packCopyDependencies := {
         val log = streams.value.log
 
         val distinctDpJars   = packModuleEntries.value.map(_.file)
@@ -265,10 +260,9 @@ object PackPlugin extends AutoPlugin with PackArchive {
         libs.foreach(l => IO.copyFile(l, copyDepTargetDir / l.getName()))
 
         log.info(s"Copied ${distinctDpJars.size + libs.size} jars to ${copyDepTargetDir}")
-      }
-    ),
+    },
     packEnvVars := Map.empty,
-    Def.derive(pack := {
+    pack := {
       val out        = streams.value
       val logPrefix  = "[" + name.value + "] "
       val base: File = new File(".") // Using the working directory as base for readability
@@ -481,8 +475,8 @@ object PackPlugin extends AutoPlugin with PackArchive {
 
       out.log.info(logPrefix + "done.")
       distDir
-    }),
-    Def.derive(packInstall := {
+    },
+    packInstall := {
       val arg: Option[String] = targetFolderParser.parsed
       val packDir             = pack.value
       val cmd = arg match {
@@ -492,7 +486,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
           s"make install"
       }
       sys.process.Process(cmd, Some(packDir)).!
-    })
+    }
   )
 
   private def getFromAllProjects[T](


### PR DESCRIPTION
## Summary
- Updates sbt 2.x version from 2.0.0-M4 to 2.0.0-RC2 for Scala 3 cross-building
- Removes deprecated `Def.derive()` calls that are no longer supported in sbt 2.x
- Enables CI testing for sbt 2.x plugin

## Changes
- **build.sbt**: Updated sbt version for Scala 3 from 2.0.0-M4 to 2.0.0-RC2
- **PackPlugin.scala & PackArchive.scala**: Removed all `Def.derive()` wrappers as they're deprecated in sbt 2.x
- **.github/workflows/test.yml**: Uncommented and enabled sbt 2.x CI testing
- **PluginCompat.scala**: Added initial imports for JsonFormat support (sbt 2.x requirement)

## Status
This PR enables basic cross-building with sbt 2.0.0-RC2. The plugin compiles successfully with Scala 2.12 (sbt 1.x) and has partial support for Scala 3 (sbt 2.x).

## Known Issues
Some tasks in sbt 2.x may require additional JsonFormat instances for proper caching. This is a known limitation when migrating to sbt 2.x and will need to be addressed as the sbt 2.0 APIs stabilize.

## Test Plan
- [x] Compiles with Scala 2.12 + sbt 1.x
- [x] Compiles with Scala 3 + sbt 2.x (with warnings about JsonFormat)
- [x] CI tests enabled for both sbt versions

🤖 Generated with [Claude Code](https://claude.ai/code)