### PR TITLE
Enable CI for sbt 2.0.0-RC2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,24 +47,24 @@ jobs:
       - name: scripted tests (sbt 1.x)
         run: ./sbt "++ 2.12 test" "++ 2.12 scripted"
 
-  # test_sbt2_plugin:
-  #   name: plugin test (sbt 2.x)
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - os: ubuntu-latest
-  #           distribution: temurin
-  #           java: 21
-  #         - os: ubuntu-latest
-  #           distribution: temurin
-  #           java: 24
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-java@v4
-  #       with:
-  #         distribution: "${{ matrix.distribution }}"
-  #         java-version: "${{ matrix.java }}"
-  #     - name: scripted tests (sbt 2.x)
-  #       run: ./sbt "++ 3 test" "++ 3 scripted"
+  test_sbt2_plugin:
+    name: plugin test (sbt 2.x)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            distribution: temurin
+            java: 21
+          - os: ubuntu-latest
+            distribution: temurin
+            java: 24
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "${{ matrix.distribution }}"
+          java-version: "${{ matrix.java }}"
+      - name: scripted tests (sbt 2.x)
+        run: ./sbt "++ 3 test" "++ 3 scripted"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ pluginCrossBuild / sbtVersion := {
     case "2.12" =>
       (pluginCrossBuild / sbtVersion).value
     case _ =>
-      "2.0.0-M4"
+      "2.0.0-RC2"
   }
 }
 

--- a/src/main/scala-2/xerial/sbt/pack/PluginCompat.scala
+++ b/src/main/scala-2/xerial/sbt/pack/PluginCompat.scala
@@ -18,4 +18,10 @@ private[pack] object PluginCompat {
     cp.map(_.data.toPath()).toVector
   def toFiles(cp: Seq[Attributed[File]])(implicit conv: FileConverter): Vector[File] =
     cp.map(_.data).toVector
+  
+  // Compatibility wrapper for sbt 1.x (no-op, just returns the value)
+  def uncached[T](value: => T): T = value
+  
+  // Dummy for sbt 1.x (not needed but imported in common code)
+  val fileRefJsonFormat = ()
 }

--- a/src/main/scala-2/xerial/sbt/pack/PluginCompat.scala
+++ b/src/main/scala-2/xerial/sbt/pack/PluginCompat.scala
@@ -18,10 +18,10 @@ private[pack] object PluginCompat {
     cp.map(_.data.toPath()).toVector
   def toFiles(cp: Seq[Attributed[File]])(implicit conv: FileConverter): Vector[File] =
     cp.map(_.data).toVector
-  
+
   // Compatibility wrapper for sbt 1.x (no-op, just returns the value)
   def uncached[T](value: => T): T = value
-  
+
   // Dummy for sbt 1.x (not needed but imported in common code)
   val fileRefJsonFormat = ()
 }

--- a/src/main/scala-3/xerial/sbt/pack/PluginCompat.scala
+++ b/src/main/scala-3/xerial/sbt/pack/PluginCompat.scala
@@ -4,6 +4,7 @@ import java.nio.file.Path as NioPath
 import sbt.*
 import sbt.internal.inc.PlainVirtualFileConverter
 import xsbti.{FileConverter, HashedVirtualFileRef, VirtualFile}
+import sjsonnew.JsonFormat
 
 // See https://www.eed3si9n.com/sbt-assembly-2.3.0
 private[pack] object PluginCompat:
@@ -23,3 +24,24 @@ private[pack] object PluginCompat:
     cp.map(toNioPath).toVector
   inline def toFiles(cp: Seq[Attributed[HashedVirtualFileRef]])(using conv: FileConverter): Vector[File] =
     toNioPaths(cp).map(_.toFile())
+
+  // JSON formats for sbt 2.0 compatibility - provide all needed instances
+  import sjsonnew.{Builder, Unbuilder, JsonFormat}
+  import sjsonnew.BasicJsonProtocol
+  import sbt.internal.util.codec.JsonProtocol.{*, given}
+  
+  // Provide JsonFormat for FileRef
+  given fileRefJsonFormat: JsonFormat[FileRef] = new JsonFormat[FileRef] {
+    override def write[J](obj: FileRef, builder: Builder[J]): Unit = {
+      val path = conv.toPath(obj).toString
+      BasicJsonProtocol.StringJsonFormat.write(path, builder)
+    }
+    
+    override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): FileRef = {
+      val path = BasicJsonProtocol.StringJsonFormat.read(jsOpt, unbuilder)
+      conv.toVirtualFile(NioPath.of(path))
+    }
+  }
+  
+  // Compatibility wrapper for sbt 2.0
+  def uncached[T](value: => T): T = value

--- a/src/main/scala/xerial/sbt/pack/PackArchive.scala
+++ b/src/main/scala/xerial/sbt/pack/PackArchive.scala
@@ -106,7 +106,7 @@ trait PackArchive {
       createTarEntry
     ).value,
     packArchiveZip := createArchive[ZipArchiveEntry]("zip", new ZipArchiveOutputStream(_), createZipEntry).value,
-    packArchive := Seq(packArchiveTgz.value, packArchiveZip.value)
+    packArchive    := Seq(packArchiveTgz.value, packArchiveZip.value)
   )
 
   def publishPackArchiveTgz: SettingsDefinition =

--- a/src/main/scala/xerial/sbt/pack/PackArchive.scala
+++ b/src/main/scala/xerial/sbt/pack/PackArchive.scala
@@ -12,6 +12,7 @@ import sbt.Keys.*
 import sbt.*
 import PluginCompat.*
 import PluginCompat.toFile
+import PluginCompat.fileRefJsonFormat
 
 trait PackArchive {
 
@@ -89,31 +90,23 @@ trait PackArchive {
     packArchiveTbzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.bz2"),
     packArchiveTxzArtifact := Artifact(packArchivePrefix.value, "arch", "tar.xz"),
     packArchiveZipArtifact := Artifact(packArchivePrefix.value, "arch", "zip"),
-    Def.derive(
-      packArchiveTgz := createArchive[TarArchiveEntry](
-        "tar.gz",
-        (fos) => createTarArchiveOutputStream(new GzipCompressorOutputStream(fos)),
-        createTarEntry
-      ).value
-    ),
-    Def.derive(
-      packArchiveTbz := createArchive[TarArchiveEntry](
-        "tar.bz2",
-        (fos) => createTarArchiveOutputStream(new BZip2CompressorOutputStream(fos)),
-        createTarEntry
-      ).value
-    ),
-    Def.derive(
-      packArchiveTxz := createArchive[TarArchiveEntry](
-        "tar.xz",
-        (fos) => createTarArchiveOutputStream(new XZCompressorOutputStream(fos)),
-        createTarEntry
-      ).value
-    ),
-    Def.derive(
-      packArchiveZip := createArchive[ZipArchiveEntry]("zip", new ZipArchiveOutputStream(_), createZipEntry).value
-    ),
-    Def.derive(packArchive := Seq(packArchiveTgz.value, packArchiveZip.value))
+    packArchiveTgz := createArchive[TarArchiveEntry](
+      "tar.gz",
+      (fos) => createTarArchiveOutputStream(new GzipCompressorOutputStream(fos)),
+      createTarEntry
+    ).value,
+    packArchiveTbz := createArchive[TarArchiveEntry](
+      "tar.bz2",
+      (fos) => createTarArchiveOutputStream(new BZip2CompressorOutputStream(fos)),
+      createTarEntry
+    ).value,
+    packArchiveTxz := createArchive[TarArchiveEntry](
+      "tar.xz",
+      (fos) => createTarArchiveOutputStream(new XZCompressorOutputStream(fos)),
+      createTarEntry
+    ).value,
+    packArchiveZip := createArchive[ZipArchiveEntry]("zip", new ZipArchiveOutputStream(_), createZipEntry).value,
+    packArchive := Seq(packArchiveTgz.value, packArchiveZip.value)
   )
 
   def publishPackArchiveTgz: SettingsDefinition =


### PR DESCRIPTION
## Summary
- Upgrade sbt version from 2.0.0-M4 to 2.0.0-RC2 for Scala 3 cross-compilation
- Enable CI workflow for sbt 2.x testing
- Add compatibility layer to handle differences between sbt 1.x and 2.0

## Changes
- Updated `build.sbt` to use sbt 2.0.0-RC2 for Scala 3
- Enabled the sbt 2.x CI workflow in `.github/workflows/test.yml`
- Added JsonFormat instances in PluginCompat for sbt 2.0 compatibility
- Removed `Def.derive` wrappers that were causing issues in sbt 2.0

## Note
Full sbt 2.0 compilation still requires additional work for HashWriter instances and other caching-related changes, but this PR enables CI to start testing sbt 2.0 compatibility.

## Test plan
- [x] sbt 1.x compilation works (Scala 2.12)
- [ ] sbt 2.x compilation (partial - CI will test)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)