### PR TITLE
Add packIncludedProjectScopes setting for filtering project dependency scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ the `packCopyDependenciesTarget` setting.
 By default, a symbolic link will be created.  By setting `packCopyDependenciesUseSymbolicLinks` to `false`, 
 the files will be copied instead of symlinking.   A symbolic link is faster and uses less disk space.
 
+By default, only dependencies from child modules with mapping `compile->` will be copied.  By setting
+`includedDependencyMappings` to a list of mappings, you can control which dependencies are copied.
+
 It can be used e.g. for copying dependencies of a webapp to `WEB-INF/lib`
 
 See an [example](src/sbt-test/sbt-pack/copy-dependencies) project.

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ the `packCopyDependenciesTarget` setting.
 By default, a symbolic link will be created.  By setting `packCopyDependenciesUseSymbolicLinks` to `false`, 
 the files will be copied instead of symlinking.   A symbolic link is faster and uses less disk space.
 
-By default, only dependencies from child modules with mapping `compile->` will be copied.  By setting
-`includedDependencyMappings` to a list of mappings, you can control which dependencies are copied.
+By default, only dependencies from child modules with scope `compile->` will be copied.  By setting
+`packIncludedProjectScopes` to a list of scopes (e.g., `Seq("compile->", "test->")`), you can control which project dependencies are included.
 
 It can be used e.g. for copying dependencies of a webapp to `WEB-INF/lib`
 

--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -522,7 +522,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
       def isExcluded(p: ProjectRef) = exclude.contains(p.project)
 
       def isMatchingConfig(cp: ClasspathDep[ProjectRef]) =
-        cp.configuration.forall(c => includedDependencyMappings.exists(c.contains(_)))
+        includedDependencyMappings.nonEmpty && cp.configuration.forall(c => includedDependencyMappings.exists(c.contains(_)))
 
       // Traverse all dependent projects
       val children = Project

--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -522,7 +522,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
       def isExcluded(p: ProjectRef) = exclude.contains(p.project)
 
       def isMatchingConfig(cp: ClasspathDep[ProjectRef]) =
-        includedDependencyMappings.nonEmpty && cp.configuration.forall(c => includedDependencyMappings.exists(c.contains(_)))
+        cp.configuration.forall(c => includedDependencyMappings.exists(c.contains(_)))
 
       // Traverse all dependent projects
       val children = Project

--- a/src/main/scala/xerial/sbt/pack/PackPlugin.scala
+++ b/src/main/scala/xerial/sbt/pack/PackPlugin.scala
@@ -93,8 +93,8 @@ object PackPlugin extends AutoPlugin with PackArchive {
       taskKey[Boolean]("""use symbolic links instead of copying for <packCopyDependencies>.
         		|The use of symbolic links allows faster processing and save disk space.
       	  """.stripMargin)
-    val includedDependencyMappings =
-      settingKey[Seq[String]]("dependency mappings to include when packaging, default is Seq(\"compile->\")")
+    val packIncludedProjectScopes =
+      settingKey[Seq[String]]("project dependency scopes to include when packaging, default is Seq(\"compile->\")")
 
     val packArchivePrefix = settingKey[String]("prefix of (prefix)-(version).(format) archive file name")
     val packArchiveName   = settingKey[String]("archive file name. Default is (project-name)-(version)")
@@ -156,7 +156,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
           discoveredMainClasses,
           state.value,
           packExclude.value,
-          includedDependencyMappings.value
+          packIncludedProjectScopes.value
         )
       Def.task {
         mainClasses.value
@@ -171,7 +171,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
           unmanagedJars,
           state.value,
           packExclude.value,
-          includedDependencyMappings.value
+          packIncludedProjectScopes.value
         )
       Def.task { allUnmanagedJars.value }
     }.value,
@@ -185,7 +185,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
               packageBin,
               state.value,
               packExcludeLibJars.value,
-              includedDependencyMappings.value
+              packIncludedProjectScopes.value
             )
           ) ++ c.extendsConfigs.flatMap(libJarsFromConfiguration)
 
@@ -251,7 +251,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
       }
     ),
     packCopyDependenciesUseSymbolicLinks := true,
-    includedDependencyMappings           := Seq("compile->"),
+    packIncludedProjectScopes            := Seq("compile->"),
     packCopyDependenciesTarget           := target.value / "lib",
     Def.derive(
       packCopyDependencies := {
@@ -513,7 +513,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
       targetTask: TaskKey[T],
       state: State,
       exclude: Seq[String],
-      includedDependencyMappings: Seq[String]
+      packIncludedProjectScopes: Seq[String]
   ): Task[Seq[(T, ProjectRef)]] = {
     val extracted = Project.extract(state)
     val structure = extracted.structure
@@ -522,7 +522,7 @@ object PackPlugin extends AutoPlugin with PackArchive {
       def isExcluded(p: ProjectRef) = exclude.contains(p.project)
 
       def isMatchingConfig(cp: ClasspathDep[ProjectRef]) =
-        cp.configuration.forall(c => includedDependencyMappings.exists(c.contains(_)))
+        cp.configuration.forall(c => packIncludedProjectScopes.exists(c.contains(_)))
 
       // Traverse all dependent projects
       val children = Project

--- a/src/sbt-test/sbt-pack/copy-dependencies/build.sbt
+++ b/src/sbt-test/sbt-pack/copy-dependencies/build.sbt
@@ -51,7 +51,7 @@ lazy val module3 =
 
 lazy val module4 =
   project
-    .dependsOn(module2)
+    .dependsOn(module2, module3 % "test->compile")
     .settings(commonSettings)
     .settings(
       libraryDependencies ++= Seq(

--- a/src/sbt-test/sbt-pack/copy-dependencies/test
+++ b/src/sbt-test/sbt-pack/copy-dependencies/test
@@ -61,3 +61,15 @@ $exists module4/target/WEB-INF/lib/commons-digester-2.1.jar
 $exists module4/target/WEB-INF/lib/commons-logging-1.1.1.jar
 $exists module4/target/WEB-INF/lib/slf4j-api-1.7.6.jar
 -$exists module4/target/WEB-INF/lib/snappy-java-1.1.1.6.jar
+
+>set module4 / includedDependencyMappings := Seq("compile->", "test->")
+>module4 / packCopyDependencies
+#$exec ls module4/target/WEB-INF/lib
+-$exists module4/target/WEB-INF/lib/module2-0.1.jar
+$exists module4/target/WEB-INF/lib/module3-0.1.jar
+$exists module4/target/WEB-INF/lib/module4-0.1.jar
+$exists module4/target/WEB-INF/lib/commons-collections-3.2.1.jar
+$exists module4/target/WEB-INF/lib/commons-digester-2.1.jar
+$exists module4/target/WEB-INF/lib/commons-logging-1.1.1.jar
+$exists module4/target/WEB-INF/lib/slf4j-api-1.7.6.jar
+-$exists module4/target/WEB-INF/lib/snappy-java-1.1.1.6.jar

--- a/src/sbt-test/sbt-pack/copy-dependencies/test
+++ b/src/sbt-test/sbt-pack/copy-dependencies/test
@@ -73,3 +73,15 @@ $exists module4/target/WEB-INF/lib/commons-digester-2.1.jar
 $exists module4/target/WEB-INF/lib/commons-logging-1.1.1.jar
 $exists module4/target/WEB-INF/lib/slf4j-api-1.7.6.jar
 -$exists module4/target/WEB-INF/lib/snappy-java-1.1.1.6.jar
+
+>set module4 / includedDependencyMappings := Seq()
+>module4 / packCopyDependencies
+#$exec ls module4/target/WEB-INF/lib
+-$exists module4/target/WEB-INF/lib/module2-0.1.jar
+-$exists module4/target/WEB-INF/lib/module3-0.1.jar
+$exists module4/target/WEB-INF/lib/module4-0.1.jar
+$exists module4/target/WEB-INF/lib/commons-collections-3.2.1.jar
+$exists module4/target/WEB-INF/lib/commons-digester-2.1.jar
+$exists module4/target/WEB-INF/lib/commons-logging-1.1.1.jar
+$exists module4/target/WEB-INF/lib/slf4j-api-1.7.6.jar
+-$exists module4/target/WEB-INF/lib/snappy-java-1.1.1.6.jar

--- a/src/sbt-test/sbt-pack/copy-dependencies/test
+++ b/src/sbt-test/sbt-pack/copy-dependencies/test
@@ -62,7 +62,7 @@ $exists module4/target/WEB-INF/lib/commons-logging-1.1.1.jar
 $exists module4/target/WEB-INF/lib/slf4j-api-1.7.6.jar
 -$exists module4/target/WEB-INF/lib/snappy-java-1.1.1.6.jar
 
->set module4 / includedDependencyMappings := Seq("compile->", "test->")
+>set module4 / packIncludedProjectScopes := Seq("compile->", "test->")
 >module4 / packCopyDependencies
 #$exec ls module4/target/WEB-INF/lib
 -$exists module4/target/WEB-INF/lib/module2-0.1.jar
@@ -74,7 +74,7 @@ $exists module4/target/WEB-INF/lib/commons-logging-1.1.1.jar
 $exists module4/target/WEB-INF/lib/slf4j-api-1.7.6.jar
 -$exists module4/target/WEB-INF/lib/snappy-java-1.1.1.6.jar
 
->set module4 / includedDependencyMappings := Seq()
+>set module4 / packIncludedProjectScopes := Seq()
 >module4 / packCopyDependencies
 #$exec ls module4/target/WEB-INF/lib
 -$exists module4/target/WEB-INF/lib/module2-0.1.jar


### PR DESCRIPTION
Motivation:
With our project we are using PackPlugin and it works really well. However, we have some specific configuration so we are using dependencies from some child modules in scope "test->compile":

`.dependsOn(
    common % "test->compile"
  )`

Currently allowed mapping is hardcoded here:

`def isCompileConfig(cp: ClasspathDep[ProjectRef]) = cp.configuration.forall(_.contains("compile->"))`

In scope of this PR I just added possibility to override allowed mappings.